### PR TITLE
Add make target 'clean-tf-cache' that removes the .terraform caches.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,13 @@ destroy-tf-backend-cf-stack:
 	--stack-name $(TF_S3_BACKEND_NAME) \
 	--region $(AWS_SECONDARY_REGION)
 
+#################### Terraform Cache Clean-up ####################
+
+clean-tf-cache:
+	@echo "Removing Terraform caches in iac/roots/."
+	find . -type d -name ".terraform" -exec rm -rf {} +
+	@echo "Complete"
+
 #################### KMS Keys ####################
 
 deploy-kms-keys:


### PR DESCRIPTION
Add make target 'clean-tf-cache' that removes the .terraform directory in all iac/roots directories.

**Issue #, if available:**
n/a

**Description of changes:**
After deploying the solution, the repo takes up over 15GB of space due to all the copies of the Terraform AWS provider module.  This PR adds a make target that can be run to remove the .terraform cache directory in each of the iac/roots directories.  Running the `make clean-tf-cache` target reduces disk usage from >15GB  to about 100MB.  The provider and module versions used are kept in the iac/roots/*/.terraform.lock.hcl files, so upon re-running a make target, the same versions of the providers and modules are downloaded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
