### PR TITLE
Correct region parameter in backend.tf files to use ###AWS_PRIMARY_REGION###

### DIFF
--- a/iac/roots/athena/backend.tf
+++ b/iac/roots/athena/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/athena/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/datalakes/billing-cur/backend.tf
+++ b/iac/roots/datalakes/billing-cur/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/billing-cur/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/datalakes/billing/backend.tf
+++ b/iac/roots/datalakes/billing/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/billing/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/datalakes/inventory/backend.tf
+++ b/iac/roots/datalakes/inventory/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/inventory/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/datalakes/splunk/backend.tf
+++ b/iac/roots/datalakes/splunk/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/splunk/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/datazone/dz-consumer-project/backend.tf
+++ b/iac/roots/datazone/dz-consumer-project/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/dz-consumer-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/datazone/dz-custom-project/backend.tf
+++ b/iac/roots/datazone/dz-custom-project/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/dz-custom-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/datazone/dz-domain/backend.tf
+++ b/iac/roots/datazone/dz-domain/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/dz-domain/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/datazone/dz-producer-project/backend.tf
+++ b/iac/roots/datazone/dz-producer-project/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/dz-producer-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/datazone/dz-project-prereq/backend.tf
+++ b/iac/roots/datazone/dz-project-prereq/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/dz-project-prereq/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/foundation/buckets/backend.tf
+++ b/iac/roots/foundation/buckets/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/buckets/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/foundation/iam-roles/backend.tf
+++ b/iac/roots/foundation/iam-roles/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/iam-roles/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/foundation/kms-keys/backend.tf
+++ b/iac/roots/foundation/kms-keys/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/kms-keys/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/idc/idc-acc/backend.tf
+++ b/iac/roots/idc/idc-acc/backend.tf
@@ -5,7 +5,7 @@ terraform {
   backend "s3" {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/idc-acc/terraform.tfstate"
     encrypt        = true
   }

--- a/iac/roots/idc/idc-org/backend.tf
+++ b/iac/roots/idc/idc-org/backend.tf
@@ -5,7 +5,7 @@ terraform {
   backend "s3" {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/idc-org/terraform.tfstate"
     encrypt        = true
   }

--- a/iac/roots/network/backend.tf
+++ b/iac/roots/network/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/network/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/quicksight/dataset/backend.tf
+++ b/iac/roots/quicksight/dataset/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/dataset/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/quicksight/subscription/backend.tf
+++ b/iac/roots/quicksight/subscription/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/subscription/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/sagemaker/consumer-project/backend.tf
+++ b/iac/roots/sagemaker/consumer-project/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/consumer-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/sagemaker/domain-prereq/backend.tf
+++ b/iac/roots/sagemaker/domain-prereq/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/domain-prereq/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/sagemaker/domain/backend.tf
+++ b/iac/roots/sagemaker/domain/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/domain/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/sagemaker/producer-project/backend.tf
+++ b/iac/roots/sagemaker/producer-project/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/producer-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/sagemaker/project-config/backend.tf
+++ b/iac/roots/sagemaker/project-config/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/project-config/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/sagemaker/project-prereq/backend.tf
+++ b/iac/roots/sagemaker/project-prereq/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/project-prereq/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/sagemaker/project-user/backend.tf
+++ b/iac/roots/sagemaker/project-user/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/project-user/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/sagemaker/projects/backend.tf
+++ b/iac/roots/sagemaker/projects/backend.tf
@@ -8,7 +8,7 @@ terraform {
     bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
     key            = "###ENV_NAME###/projects/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_DEFAULT_REGION###"
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }


### PR DESCRIPTION
**Issue #, if available:**
n/a

**Description of changes:**
When running `make init` the user is prompted for three region values:
- default region (as configured in .aws/config or credentials)
- primary region (where to deploy the vast majority of resources)
- secondary region (where to place alternate s3 bucket for TF state and create replication rule)

The init script then replaces values in a number of files with the regions provided by the user.

Scenario:
- default region: us-east-1
- primary region: us-east-2
- secondary region: us-east-1

When providing a primary region that does not match the default region (as above), the s3 buckets are correctly created in the primary and secondary region and the DynamoDB table for locking is created in the primary region.  However, the `backend.tf` files for each set of Terraform code all have the region parameter set to the default region.  As such, when trying to run the Terraform it's not able to find the Dynamo table to create the lock because the table is in the primary region, not the default region.

Updating the `backend.tf` files to have the region parameter set to the primary region rather than the default region should correct this.  This PR updates all of the `backend.tf` files.
```
region = "###AWS_DEFAULT_REGION###"

to

region = "###AWS_PRIMARY_REGION###"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
