### PR TITLE
Fix backend bucket to use Primary region rather than Default region. (Follow-up to PR #6.)

### DIFF
--- a/iac/roots/athena/backend.tf
+++ b/iac/roots/athena/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/athena/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/datalakes/billing-cur/backend.tf
+++ b/iac/roots/datalakes/billing-cur/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/billing-cur/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/datalakes/billing/backend.tf
+++ b/iac/roots/datalakes/billing/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/billing/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/datalakes/inventory/backend.tf
+++ b/iac/roots/datalakes/inventory/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/inventory/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/datalakes/splunk/backend.tf
+++ b/iac/roots/datalakes/splunk/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/splunk/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/datazone/dz-consumer-project/backend.tf
+++ b/iac/roots/datazone/dz-consumer-project/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/dz-consumer-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/datazone/dz-custom-project/backend.tf
+++ b/iac/roots/datazone/dz-custom-project/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/dz-custom-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/datazone/dz-domain/backend.tf
+++ b/iac/roots/datazone/dz-domain/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/dz-domain/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/datazone/dz-producer-project/backend.tf
+++ b/iac/roots/datazone/dz-producer-project/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/dz-producer-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/datazone/dz-project-prereq/backend.tf
+++ b/iac/roots/datazone/dz-project-prereq/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/dz-project-prereq/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/foundation/buckets/backend.tf
+++ b/iac/roots/foundation/buckets/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/buckets/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/foundation/iam-roles/backend.tf
+++ b/iac/roots/foundation/iam-roles/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/iam-roles/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/foundation/kms-keys/backend.tf
+++ b/iac/roots/foundation/kms-keys/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/kms-keys/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/idc/idc-acc/backend.tf
+++ b/iac/roots/idc/idc-acc/backend.tf
@@ -3,7 +3,7 @@
 
 terraform {
   backend "s3" {
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/idc-acc/terraform.tfstate"

--- a/iac/roots/idc/idc-org/backend.tf
+++ b/iac/roots/idc/idc-org/backend.tf
@@ -3,7 +3,7 @@
 
 terraform {
   backend "s3" {
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/idc-org/terraform.tfstate"

--- a/iac/roots/network/backend.tf
+++ b/iac/roots/network/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/network/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/quicksight/dataset/backend.tf
+++ b/iac/roots/quicksight/dataset/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/dataset/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/quicksight/subscription/backend.tf
+++ b/iac/roots/quicksight/subscription/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/subscription/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/sagemaker/consumer-project/backend.tf
+++ b/iac/roots/sagemaker/consumer-project/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/consumer-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/sagemaker/domain-prereq/backend.tf
+++ b/iac/roots/sagemaker/domain-prereq/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/domain-prereq/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###" 
+    region         = "###AWS_PRIMARY_REGION###"
     encrypt        = true
   }
 }

--- a/iac/roots/sagemaker/domain/backend.tf
+++ b/iac/roots/sagemaker/domain/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/domain/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/sagemaker/producer-project/backend.tf
+++ b/iac/roots/sagemaker/producer-project/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/producer-project/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/sagemaker/project-config/backend.tf
+++ b/iac/roots/sagemaker/project-config/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/project-config/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/sagemaker/project-prereq/backend.tf
+++ b/iac/roots/sagemaker/project-prereq/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/project-prereq/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"

--- a/iac/roots/sagemaker/project-user/backend.tf
+++ b/iac/roots/sagemaker/project-user/backend.tf
@@ -5,7 +5,7 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"
     key            = "###ENV_NAME###/project-user/terraform.tfstate"
     dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
     region         = "###AWS_PRIMARY_REGION###"


### PR DESCRIPTION
**Issue #, if available:**
n/a

**Description of changes:**
Follow up to PR #6 –> bucket also needs to be updated from
`"###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"`
to
`"###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_PRIMARY_REGION###"`

--> **MAJOR ISSUES** still exist in `make deploy-domain` that I have not been able to work through.  Seems like local provisioners do not all have `--region ${local.region}` but I have not been able to find all of the issues to get a successful run.  Also, have not been able to test make targets later than domain based on the problems.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
