### PR TITLE
Move from deprecated Terraform backend locking using `dynamodb_table` to `use_lockfile`.

### DIFF
--- a/iac/roots/athena/backend.tf
+++ b/iac/roots/athena/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/athena/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/athena/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/datalakes/billing-cur/backend.tf
+++ b/iac/roots/datalakes/billing-cur/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/billing-cur/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/billing-cur/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/datalakes/billing/backend.tf
+++ b/iac/roots/datalakes/billing/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/billing/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/billing/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/datalakes/inventory/backend.tf
+++ b/iac/roots/datalakes/inventory/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/inventory/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/inventory/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/datalakes/splunk/backend.tf
+++ b/iac/roots/datalakes/splunk/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/splunk/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/splunk/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/datazone/dz-consumer-project/backend.tf
+++ b/iac/roots/datazone/dz-consumer-project/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/dz-consumer-project/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/dz-consumer-project/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/datazone/dz-custom-project/backend.tf
+++ b/iac/roots/datazone/dz-custom-project/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/dz-custom-project/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/dz-custom-project/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/datazone/dz-domain/backend.tf
+++ b/iac/roots/datazone/dz-domain/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/dz-domain/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/dz-domain/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/datazone/dz-producer-project/backend.tf
+++ b/iac/roots/datazone/dz-producer-project/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/dz-producer-project/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/dz-producer-project/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/datazone/dz-project-prereq/backend.tf
+++ b/iac/roots/datazone/dz-project-prereq/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/dz-project-prereq/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/dz-project-prereq/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/foundation/buckets/backend.tf
+++ b/iac/roots/foundation/buckets/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/buckets/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/buckets/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/foundation/iam-roles/backend.tf
+++ b/iac/roots/foundation/iam-roles/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/iam-roles/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/iam-roles/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/foundation/kms-keys/backend.tf
+++ b/iac/roots/foundation/kms-keys/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/kms-keys/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/kms-keys/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/idc/idc-acc/backend.tf
+++ b/iac/roots/idc/idc-acc/backend.tf
@@ -3,10 +3,10 @@
 
 terraform {
   backend "s3" {
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    key            = "###ENV_NAME###/idc-acc/terraform.tfstate"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    key          = "###ENV_NAME###/idc-acc/terraform.tfstate"
+    encrypt      = true
   }
 }

--- a/iac/roots/idc/idc-org/backend.tf
+++ b/iac/roots/idc/idc-org/backend.tf
@@ -3,10 +3,10 @@
 
 terraform {
   backend "s3" {
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    key            = "###ENV_NAME###/idc-org/terraform.tfstate"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    key          = "###ENV_NAME###/idc-org/terraform.tfstate"
+    encrypt      = true
   }
 }

--- a/iac/roots/network/backend.tf
+++ b/iac/roots/network/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/network/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/network/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/quicksight/dataset/backend.tf
+++ b/iac/roots/quicksight/dataset/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/dataset/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/dataset/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/quicksight/subscription/backend.tf
+++ b/iac/roots/quicksight/subscription/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/subscription/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/subscription/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/sagemaker/consumer-project/backend.tf
+++ b/iac/roots/sagemaker/consumer-project/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/consumer-project/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/consumer-project/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/sagemaker/domain-prereq/backend.tf
+++ b/iac/roots/sagemaker/domain-prereq/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/domain-prereq/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###" 
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/domain-prereq/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/sagemaker/domain/backend.tf
+++ b/iac/roots/sagemaker/domain/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/domain/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/domain/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/sagemaker/producer-project/backend.tf
+++ b/iac/roots/sagemaker/producer-project/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/producer-project/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/producer-project/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/sagemaker/project-config/backend.tf
+++ b/iac/roots/sagemaker/project-config/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/project-config/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/project-config/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/sagemaker/project-prereq/backend.tf
+++ b/iac/roots/sagemaker/project-prereq/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/project-prereq/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/project-prereq/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }

--- a/iac/roots/sagemaker/project-user/backend.tf
+++ b/iac/roots/sagemaker/project-user/backend.tf
@@ -5,10 +5,10 @@ terraform {
 
   backend "s3" {
 
-    bucket         = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
-    key            = "###ENV_NAME###/project-user/terraform.tfstate"
-    dynamodb_table = "###TF_S3_BACKEND_NAME###-lock"
-    region         = "###AWS_PRIMARY_REGION###"
-    encrypt        = true
+    bucket       = "###TF_S3_BACKEND_NAME###-###AWS_ACCOUNT_ID###-###AWS_DEFAULT_REGION###"
+    key          = "###ENV_NAME###/project-user/terraform.tfstate"
+    use_lockfile = true
+    region       = "###AWS_PRIMARY_REGION###"
+    encrypt      = true
   }
 }


### PR DESCRIPTION
**Issue #, if available:**
n/a

**Description of changes:**
Terraform 1.11.4 is the [current version](https://github.com/hashicorp/terraform/releases/tag/v1.11.4) as of 4/9/2025.  In Terraform 1.11.x and greater, using `dynamodb_table` has been deprecated in favor of `use_lockfile`.  Running the code with 1.11.x+ throws following warning.

```
|
│ Warning: Deprecated Parameter
│
│   on backend.tf line 10, in terraform:
│   10:     dynamodb_table = "daivi-ibehr-tf-back-end-lock"
│
│ The parameter "dynamodb_table" is deprecated. Use parameter "use_lockfile" instead.
|
```

Included code works for Terraform 1.11.x and should work for 1.10.x.  Project should be updated to require Terraform>=1.10.x which supports `use_lockfile`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
