### PR TITLE
feat: add MSK cluster dependency to EC2 instance resource

### DIFF
--- a/iac/roots/foundation/msk-serverless/ec2.tf
+++ b/iac/roots/foundation/msk-serverless/ec2.tf
@@ -51,6 +51,7 @@ resource "aws_instance" "msk_client" {
   tags = {
     Name = "${var.APP}-${var.ENV}-msk-client"
   }
+  depends_on = [aws_msk_serverless_cluster.cluster]
 }
 
 resource "aws_iam_role" "client_instance_role" {


### PR DESCRIPTION
This commit addresses a resource dependency issue in the MSK serverless module by adding an explicit dependency between the EC2 client instance and the MSK serverless cluster.

## Problem
The EC2 instance resource (msk_client) was being created without explicitly waiting for the MSK serverless cluster to be fully provisioned. This could lead to race conditions where:
- The EC2 instance might start before the MSK cluster is ready
- IAM policies referencing the cluster ARN might fail during apply
- User data scripts depending on cluster availability could fail

## Solution
Added 'depends_on = [aws_msk_serverless_cluster.cluster]' to the aws_instance resource to ensure proper resource creation order.

## Changes
- Modified: iac/roots/foundation/msk-serverless/ec2.tf
- Added explicit dependency declaration to msk_client EC2 instance
- Ensures MSK cluster is fully created before EC2 instance provisioning

## Impact
- Eliminates potential race conditions during infrastructure deployment
- Improves reliability of MSK client setup
- Ensures proper resource dependency chain in Terraform execution

## Testing
This change aligns with the fix applied in the main nexus-release repository (commit 3688c71) and follows Terraform best practices for resource dependencies.

Fixes: Resource dependency issue in MSK serverless module
Related: nexus-release commit 3688c71 - Fixed MSK Issue

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
